### PR TITLE
fix: Make apollo only reply on ping and add more messages

### DIFF
--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import consola from 'consola';
-import { Client, GatewayIntentBits, REST, Routes } from 'discord.js';
+import { Client, GatewayIntentBits, MessageType, REST, Routes } from 'discord.js';
 import { and, eq } from 'drizzle-orm';
 import { startActivityCycle } from './activities.js';
 import { commands } from './commands.js';
@@ -175,7 +175,7 @@ client.on('messageCreate', async (interaction) => {
 });
 
 client.on('messageCreate', async (message) => {
-	if (message.author.bot) return;
+	if (message.author.bot || message.type === MessageType.Reply && message.mentions.repliedUser?.id === client.user?.id) return;
 
 	// biome-ignore lint/style/noNonNullAssertion: this is fine
 	if (message.mentions.members?.has(client.user!.id)) {

--- a/packages/apollo/src/ping-replies/binary.json
+++ b/packages/apollo/src/ping-replies/binary.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "01010111 01101000 01111001 00111111"
+}

--- a/packages/apollo/src/ping-replies/bonjour.json
+++ b/packages/apollo/src/ping-replies/bonjour.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "Bonjour!"
+}

--- a/packages/apollo/src/ping-replies/bot-confirm.json
+++ b/packages/apollo/src/ping-replies/bot-confirm.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "Yes, I am a bot. Congratulations on finding me."
+}

--- a/packages/apollo/src/ping-replies/error-404.json
+++ b/packages/apollo/src/ping-replies/error-404.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "Error 404: Attention not found."
+}

--- a/packages/apollo/src/ping-replies/if-else.json
+++ b/packages/apollo/src/ping-replies/if-else.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "My existence is a series of if/else statements and you are currently the else."
+}

--- a/packages/apollo/src/ping-replies/nitro.json
+++ b/packages/apollo/src/ping-replies/nitro.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "If I had a nickel for every time I was pinged for no reason, I could buy Nitro for the whole server."
+}

--- a/packages/apollo/src/ping-replies/ping-annoyance.json
+++ b/packages/apollo/src/ping-replies/ping-annoyance.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "Do you ping everyone this much or am I special?"
+}

--- a/packages/apollo/src/ping-replies/please-stop.json
+++ b/packages/apollo/src/ping-replies/please-stop.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../ping-replies.schema.json",
+  "message": "Please stop."
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## Description

- This PR makes Apollo only reply when directly pinged and adds more messages for better variety.

## Docs

N/A

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->
